### PR TITLE
Combine test into build phase to ensure it runs on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,6 @@ jobs:
       # Save the content of node_modules to cache for
       # the next build.
       - { save_cache: { key: 'dependency-cache-{{ checksum "package.json" }}', paths: [node_modules] } }
-  test:
-    docker:
-      - { image: 'circleci/node:7.10' }
-    steps:
-      # Checkout the build from Git.
-      - checkout
 
       # Run the tests configured in package.json.
       - { run: 'npm test' }


### PR DESCRIPTION
### Description

Circle CI test phase combined with build phase, as the test command is not automatically run when a PR is created.

### Issues fixed

None.

### Checklist

- [x] `npm test` returns no warnings or errors.
