### PR TITLE
Bugfix/line endings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,10 +22,6 @@
 			"error",
 			"tab"
 		],
-		"linebreak-style": [
-			"error",
-			"unix"
-		],
 		"quotes": [
 			"error",
 			"single"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,10 @@
 			"error",
 			"tab"
 		],
+		"linebreak-style": [
+			"error",
+			"unix"
+		],
 		"quotes": [
 			"error",
 			"single"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text eol=lf


### PR DESCRIPTION
### Description

Line-endings rule removed. (Was previously returning errors for windows users on all lines)
.gitattributes rule added to enforce line-endings at checkin.

### Issues fixed

Fixes #25 

### Checklist

- [x] `npm test` returns no warnings or errors.
