### PR TITLE
Position devtools to bottom of page by default

### DIFF
--- a/src/containers/DevTools/DevTools.js
+++ b/src/containers/DevTools/DevTools.js
@@ -7,7 +7,9 @@ export default createDevTools(
 	<DockMonitor
 		toggleVisibilityKey='shift-ctrl-h'
 		changePositionKey='ctrl-q'
-		defaultIsVisible={true}>
+		defaultIsVisible={true}
+		defaultPosition='bottom'
+	>
 		<LogMonitor/>
 	</DockMonitor>
 );


### PR DESCRIPTION
### Description

Moves the Redux dev tools to the bottom of the page to stop it obscuring the right hand side of the transactions.

### Issues fixed

None.

### Checklist

- [x] `npm test` returns no warnings or errors.
