### PR TITLE
Only show transactions which are going to the focussed wallet

### DIFF
--- a/src/api/transactions.js
+++ b/src/api/transactions.js
@@ -46,7 +46,7 @@ class Transactions {
 
 		return fetch(this.buildQuery({ url, params }))
 			.then(response => response.json())
-			.then(result => result.operations);
+			.then(result => result.operations.filter(transfer => transfer.to === wallet));
 	}
 }
 


### PR DESCRIPTION
### Description

The vendor UI was showing transactions both to and from the selected wallet, due to the API request not differentiating between the two. This PR ensures that only transactions _to_ the wallet are shown

### Issues fixed

None

### Checklist

- [x] `npm test` returns no warnings or errors.
