### PR TITLE
Convert SettingsDrawer to an FSC and add to App

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ class App extends React.Component {
 		super(props);
 
 		this.state = {
-			settingsDrawerIsOpen: true,
+			settingsDrawerIsOpen: false,
 		};
 
 		this.toggleSettingsDrawer = this.toggleSettingsDrawer.bind(this);

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './reset.css';
 import './base.css';
 import './App.css';
@@ -6,22 +6,43 @@ import './App.css';
 import Header from './components/Header/Header';
 import logo from './assets/images/logo.svg';
 import TransactionList from './containers/TransactionList/TransactionList';
+import SettingsDrawer from './components/SettingsDrawer/SettingsDrawer';
 
-class App extends Component {
+class App extends React.Component {
 
-	openSettingsDraw() {
-		console.log('hello'); //eslint-disable-line
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			settingsDrawerIsOpen: true,
+		};
+
+		this.toggleSettingsDrawer = this.toggleSettingsDrawer.bind(this);
+	}
+
+	toggleSettingsDrawer() {
+		this.setState(prevState => {
+			return { settingsDrawerIsOpen: !prevState.settingsDrawerIsOpen };
+		});
 	}
 
 	render() {
+		const { settingsDrawerIsOpen } = this.state;
+
 		return (
 			<div className='App'>
-				<Header onOpenSettings={this.openSettingsDraw}>
+				<Header onOpenSettings={this.toggleSettingsDrawer}>
 					<div className='logo'>
 						<img src={logo} alt='Shed' />
 					</div>
 				</Header>
+
 				<TransactionList/>
+
+				<SettingsDrawer
+					isOpen={settingsDrawerIsOpen}
+					onClose={this.toggleSettingsDrawer}
+				>This is the settings drawer.</SettingsDrawer>
 			</div>
 		);
 	}

--- a/src/components/SettingsDrawer/SettingsDrawer.js
+++ b/src/components/SettingsDrawer/SettingsDrawer.js
@@ -3,35 +3,14 @@ import PropTypes from 'prop-types';
 
 import './SettingsDrawer.css';
 
-class SettingsDrawer extends React.Component {
-	constructor(props) {
-		super(props);
-
-		this.handleClick = this.handleClick.bind(this);
-
-		this.state = {
-			isOpen: props.isOpen,
-		};
-
-	}
-
-	handleClick(event) {
-		event.preventDefault();
-
-		this.setState({isOpen: false});
-	}
-
-	render() {
-		return (
-			<div className={`SettingsDrawer ${this.state.isOpen ? 'is-open' : 'is-closed'}`}>
-				{this.props.children}
-				<button type="button" className="close-button" onClick={this.handleClick}>
-					{this.props.closeButtonText}
-				</button>
-			</div>
-		);
-	}
-}
+const SettingsDrawer = ({ children, closeButtonText, isOpen, onClose }) => (
+	<div className={`SettingsDrawer ${isOpen ? 'is-open' : 'is-closed'}`}>
+		{children}
+		<button type="button" className="close-button" onClick={onClose}>
+			{closeButtonText}
+		</button>
+	</div>
+);
 
 SettingsDrawer.description = `
 A container for settings inputs which renders over the top of the header and transaction list.
@@ -44,13 +23,16 @@ SettingsDrawer.defaultProps = {
 
 SettingsDrawer.propTypes = {
 	/** The contents of the settings drawer. */
-	children: PropTypes.object.isRequired,
+	children: PropTypes.node,
 
 	/** If the settings drawer is open or closed. */
-	isOpen: PropTypes.bool,
+	isOpen: PropTypes.bool.isRequired,
 
 	/** Text for the close drawer button */
 	closeButtonText: PropTypes.string,
+
+	/** A callback to fire when the close button is pressed */
+	onClose: PropTypes.func,
 };
 
 export default SettingsDrawer;

--- a/src/components/SettingsDrawer/SettingsDrawer.story.js
+++ b/src/components/SettingsDrawer/SettingsDrawer.story.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf, withInfo } from '../../stories';
+import { storiesOf, withInfo, action } from '../../stories';
 
 import SettingsDrawer from './SettingsDrawer';
 
@@ -9,9 +9,22 @@ storiesOf('SettingsDrawer')
 
 	.addDecorator((story, context) => withInfo(SettingsDrawer.description)(story)(context))
 
-	.add('Static', () => (
+	.add('Open', () => (
 		<div className="reset-fixed">
-			<SettingsDrawer isOpen>
+			<SettingsDrawer isOpen={true} onClose={action('onClose')}>
+				<ul>
+					<li>Lorem ipsum dolor</li>
+					<li>Lorem ipsum dolor</li>
+					<li>Lorem ipsum dolor</li>
+					<li>Lorem ipsum dolor</li>
+				</ul>
+			</SettingsDrawer>
+		</div>
+	))
+
+	.add('Closed', () => (
+		<div className="reset-fixed">
+			<SettingsDrawer isOpen={false} onClose={action('onClose')}>
 				<ul>
 					<li>Lorem ipsum dolor</li>
 					<li>Lorem ipsum dolor</li>


### PR DESCRIPTION
### Description

Adds the settings drawer into the app, and converts it to an FSC instead of a stateful component.

### Issues fixed

None

### Checklist

- [x] `npm test` returns no warnings or errors.
