### PR TITLE
Fix Skype mixed-content and accessible Emoji warnings

### DIFF
--- a/src/components/SkypeProfile/SkypeProfile.js
+++ b/src/components/SkypeProfile/SkypeProfile.js
@@ -5,7 +5,7 @@ import './SkypeProfile.css';
 
 const SkypeProfile = props => (
 	<div className="SkypeProfile">
-		<img src={'http://api.skype.com/users/' + props.username + '/profile/avatar?size=s'} alt='Skype photo' />
+		<img src={'https://api.skype.com/users/' + props.username + '/profile/avatar?size=s'} alt='Skype avatar' />
 	</div>
 );
 

--- a/src/components/TransactionsList/TransactionsList.js
+++ b/src/components/TransactionsList/TransactionsList.js
@@ -18,7 +18,7 @@ const TransactionsList = ({ transactions }) => (
 		{transactions.length <= 0 &&
 			<p className="no-results">
 				No transactions found!
-				<span className="icon">😖</span>
+				<span className="icon" role="img" aria-label="Confounded Face Emoji">😖</span>
 			</p>
 		}
 	</div>


### PR DESCRIPTION
- Amending Skype avatar request to use HTTPS
- Amending alt text for Skype avatar to "Skype avatar", to fix webpack warning
- Adding accessibility fallback for confounded face emoji, to fix webpack warning

### Checklist

- [x] `npm test` returns no warnings or errors.
