### PR TITLE
Refactoring SettingsDrawer overlay to remove need of empty overlay <div>

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,8 +56,6 @@ class App extends React.Component {
 					<AddressInput labelText='Address' onChange={this.tempLog} />
 					<Button variant='secondary' onClick={this.toggleSettingsDrawer}>Save</Button>
 				</SettingsDrawer>
-
-				<div className="overlay"></div>
 			</div>
 		);
 	}

--- a/src/base.css
+++ b/src/base.css
@@ -39,16 +39,3 @@ body {
 	position: absolute;
 	left: -9999px;
 }
-
-.overlay {
-	background: transparent;
-	bottom: 0;
-	left: 0;
-	opacity: 0.5;
-	pointer-events: none;
-	position: absolute;
-	transition: background 1s;
-	top: 0;
-	right: 0;
-	z-index: 2;
-}

--- a/src/components/SettingsDrawer/SettingsDrawer.css
+++ b/src/components/SettingsDrawer/SettingsDrawer.css
@@ -1,4 +1,18 @@
-.SettingsDrawer {
+.SettingsDrawer:after {
+	content: "";
+	background: transparent;
+	bottom: 0;
+	left: 0;
+	opacity: 0.5;
+	pointer-events: none;
+	position: absolute;
+	transition: background 1s;
+	top: 0;
+	right: 0;
+	z-index: 2;
+}
+
+.SettingsDrawer .inner {
 	background: #313045;
 	box-sizing: border-box;
 	color: #FFFFFF;
@@ -11,13 +25,13 @@
 	z-index: 3;
 }
 
-.SettingsDrawer.is-open {
+.SettingsDrawer.is-open .inner {
 	animation: bounceInRight forwards 1s;
 	right: 0;
 }
 
 /* Faux extension to drawer so for neater entrance/exit animation  */
-.SettingsDrawer:after {
+.SettingsDrawer .inner:after {
 	content: "";
 	height: 100%;
 	width: 100px;
@@ -27,12 +41,12 @@
 	background: #313045;
 }
 
-.SettingsDrawer.is-open + .overlay {
+.SettingsDrawer.is-open:after {
 	background: #000000;
 	pointer-events: auto;
 }
 
-.SettingsDrawer.is-closed {
+.SettingsDrawer.is-closed .inner {
 	animation: bounceOutRight forwards 1s;
 	right: 0;
 }

--- a/src/components/SettingsDrawer/SettingsDrawer.js
+++ b/src/components/SettingsDrawer/SettingsDrawer.js
@@ -5,10 +5,12 @@ import './SettingsDrawer.css';
 
 const SettingsDrawer = ({ children, closeButtonText, isOpen, onClose }) => (
 	<div className={`SettingsDrawer ${isOpen ? 'is-open' : 'is-closed'}`}>
-		{children}
-		<button type="button" className="close-button" onClick={onClose}>
-			{closeButtonText}
-		</button>
+		<div className='inner'>
+			{children}
+			<button type="button" className="close-button" onClick={onClose}>
+				{closeButtonText}
+			</button>
+		</div>
 	</div>
 );
 


### PR DESCRIPTION
### Description

I made a suggestion to an earlier PR then realised it would be functionally unfeasible.

Then, after a thoughtful shower, I realised it wasn't unfeasible so here it is.

### Issues fixed

None, just refactoring.

### Checklist

- [x] `npm test` returns no warnings or errors.
