### PR TITLE
Updated TrustSetting component and made component work in application

### DIFF
--- a/src/actions/structures.js
+++ b/src/actions/structures.js
@@ -21,5 +21,5 @@ export const Transaction = struct({
 
 export const Settings = struct({
 	walletAddress: 'string',
-	trustSetting: 'string',
+	trustLevel: 'string',
 });

--- a/src/components/NumberInput/NumberInput.css
+++ b/src/components/NumberInput/NumberInput.css
@@ -16,7 +16,6 @@
 	color: #fff;
 	font-size: 16px;
 	line-height: 24px;
-	border: 0;
 	border-radius: 4px;
 	border: 1px solid transparent;
 	transition: border-color 0.3s ease;

--- a/src/components/NumberInput/NumberInput.css
+++ b/src/components/NumberInput/NumberInput.css
@@ -1,0 +1,28 @@
+.NumberInput {
+	margin-bottom: 32px;
+}
+
+.NumberInput label {
+	font-size: 14px;
+	line-height: 16px;
+	font-weight: bold;
+	margin-bottom: 6px;
+	display: block;
+}
+
+.NumberInput input {
+	background: #1B1B26;
+	padding: 12px 16px;
+	color: #fff;
+	font-size: 16px;
+	line-height: 24px;
+	border: 0;
+	border-radius: 4px;
+	border: 1px solid transparent;
+	transition: border-color 0.3s ease;
+}
+
+.NumberInput input:focus {
+	border-color: #fff;
+	outline: 0;
+}

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -5,13 +5,13 @@ import inputIdGenerator from '../../utils/inputIdGenerator';
 import './NumberInput.css';
 
 const NumberInput = ({ id = inputIdGenerator.nextIndex, labelText, value, onChange }) => (
-	<div className="NumberInput">
+	<div className='NumberInput'>
 		<label htmlFor={id}>
 			{labelText}
 		</label>
 		<input
 			id={id}
-			type="number"
+			type='number'
 			onChange={e => onChange(e.target.value)}
 			value={value}
 		/>

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import inputIdGenerator from '../../utils/inputIdGenerator';
+
+import './NumberInput.css';
+
+const NumberInput = ({ id = inputIdGenerator.nextIndex, labelText, value, onChange }) => (
+	<div className="NumberInput">
+		<label htmlFor={id}>
+			{labelText}
+		</label>
+		<input
+			id={id}
+			type="number"
+			onChange={e => onChange(e.target.value)}
+			value={value}
+		/>
+	</div>
+);
+
+NumberInput.description = `
+Basic number input complete with label
+`;
+
+NumberInput.propTypes = {
+	/** HTML id attribute for the input
+	If not present one is generated automagically */
+	id: PropTypes.string,
+
+	/** Text used for the label */
+	labelText: PropTypes.string.isRequired,
+
+	/** A function to be called when the value of the input is changed. */
+	onChange: PropTypes.func,
+
+	/** Pre-defined value for input, if present */
+	value: PropTypes.string,
+};
+
+export default NumberInput;

--- a/src/components/NumberInput/NumberInput.story.js
+++ b/src/components/NumberInput/NumberInput.story.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf, action, withInfo } from '../../stories';
+
+import NumberInput from './NumberInput';
+
+storiesOf('NumberInput')
+
+	.addDecorator((story, context) => withInfo(NumberInput.description)(story)(context))
+
+	.add('base', () => (
+		<NumberInput onChange={action('onChange')} />
+	));

--- a/src/components/TextInput/TextInput.css
+++ b/src/components/TextInput/TextInput.css
@@ -16,7 +16,6 @@
 	color: #fff;
 	font-size: 16px;
 	line-height: 24px;
-	border: 0;
 	border-radius: 4px;
 	border: 1px solid transparent;
 	transition: border-color 0.3s ease;

--- a/src/components/TrustSetting/TrustSetting.js
+++ b/src/components/TrustSetting/TrustSetting.js
@@ -5,7 +5,7 @@ import NumberInput from '../NumberInput/NumberInput';
 
 const TrustSetting = ({ id = inputIdGenerator.nextIndex, labelText, value, onChange }) => (
 	<div className='TrustSetting'>
-		<TextInput
+		<NumberInput
 			id={id}
 			labelText={labelText}
 			onChange={onChange}

--- a/src/components/TrustSetting/TrustSetting.js
+++ b/src/components/TrustSetting/TrustSetting.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import inputIdGenerator from '../../utils/inputIdGenerator';
-import TextInput from '../TextInput/TextInput';
+import NumberInput from '../NumberInput/NumberInput';
 
 const TrustSetting = ({ id = inputIdGenerator.nextIndex, labelText, value, onChange }) => (
 	<div className='TrustSetting'>

--- a/src/containers/SettingsDrawer/SettingsDrawer.js
+++ b/src/containers/SettingsDrawer/SettingsDrawer.js
@@ -11,13 +11,13 @@ import SettingsDrawer from '../../components/SettingsDrawer/SettingsDrawer';
 
 
 const mapStateToProps = state => ({
-	trustSetting: state.settings.trustConfirmationLevel,
+	trustLevel: state.settings.trustLevel,
 	walletAddress: state.settings.walletAddress,
 });
 
 const mapDispatchToProps = dispatch => ({
-	onSave: ({ walletAddress, trustSetting }) => {
-		dispatch(updateSettings({walletAddress, trustSetting}));
+	onSave: ({ walletAddress, trustLevel }) => {
+		dispatch(updateSettings({walletAddress, trustLevel}));
 		dispatch(clearTransactions());
 		dispatch(getAllTransactions());
 	},
@@ -29,15 +29,15 @@ class ConnectedSettingsDrawer extends React.Component {
 			isOpen: PropTypes.bool.isRequired,
 			onClose: PropTypes.func,
 			onSave: PropTypes.func,
-			trustSetting: PropTypes.string,
+			trustLevel: PropTypes.string,
 			walletAddress: PropTypes.string.isRequired,
 		};
 	}
 
 	constructor (props) {
 		super(props);
-		const { trustSetting, walletAddress } = props;
-		this.state = {trustSetting, walletAddress};
+		const { trustLevel, walletAddress } = props;
+		this.state = {trustLevel, walletAddress};
 
 		this.createOnChangeHandler = this.createOnChangeHandler.bind(this);
 		this.saveClickHandler = this.saveClickHandler.bind(this);
@@ -51,7 +51,7 @@ class ConnectedSettingsDrawer extends React.Component {
 
 	render () {
 		const { isOpen, onClose } = this.props;
-		const { trustSetting, walletAddress } = this.state;
+		const { trustLevel, walletAddress } = this.state;
 
 		return(
 			<SettingsDrawer
@@ -59,7 +59,7 @@ class ConnectedSettingsDrawer extends React.Component {
 				onClose={onClose}
 			>
 				<h2>Settings</h2>
-				<TrustSetting labelText='Trust' value={trustSetting} onChange={this.createOnChangeHandler('trustLevel')}/>
+				<TrustSetting labelText='Trust' value={trustLevel} onChange={this.createOnChangeHandler('trustLevel')}/>
 				<AddressInput labelText='Address' value={walletAddress} onChange={this.createOnChangeHandler('walletAddress')}/>
 				<Button variant='secondary' onClick={this.saveClickHandler}>Save</Button>
 			</SettingsDrawer>

--- a/src/reducers/slices/settings.js
+++ b/src/reducers/slices/settings.js
@@ -5,16 +5,16 @@ import env from '../../utils/environment';
 
 const initialSettings = {
 	contractAddress: env.REACT_APP_CONTRACT_ADDRESS,
-	trustConfirmationLevel: '1',
+	trustLevel: '1',
 	walletAddress: env.REACT_APP_WALLET_ADDRESS,
 };
 
 const updateSettings = (settingsState,  action) => {
 	const newWalletAddressValue = action.payload.walletAddress;
-	const newTransferSettingValue = action.payload.trustSetting;
+	const newTransferSettingValue = action.payload.trustLevel;
 
 	return {...settingsState,
-		trustConfirmationLevel: newTransferSettingValue,
+		trustLevel: newTransferSettingValue,
 		walletAddress: newWalletAddressValue,
 	};
 };


### PR DESCRIPTION
### Description

TrustSetting component now uses an input with `[type=number]` 
When a new value is input clicking on Save in the settings drawer will update the application settings in the store.

### Issues fixed

Fixes #100 

### Checklist

- [x] `npm test` returns no warnings or errors.
